### PR TITLE
UI tweaks for Pauze Planner

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -5,7 +5,7 @@
     --primary-hover: #8E1014;   /* darker shade for hover */
     --secondary-color: #B58A1A; /* accent gold */
     --background-color: #F9F7F1; /* light background */
-    --highlight-color: #E5DDC4; /* subtle highlight */
+    --highlight-color: #F1ECE4; /* lighter highlight */
     --text-color: #000000;
 }
 
@@ -50,7 +50,7 @@
 
 body {
     font-family: 'Brocha', sans-serif;
-    background: linear-gradient(rgba(249,247,241,0.9), rgba(229,221,196,0.9)), url('../images/background.jpg');
+    background: linear-gradient(rgba(249,247,241,0.95), rgba(229,221,196,0.95)), url('../images/background.jpg');
     background-size: cover;
     background-repeat: no-repeat;
     background-attachment: fixed;
@@ -82,6 +82,31 @@ input[type="text"], select {
     border-radius: 0.375rem; /* rounded-md */
     background-color: var(--background-color);
     appearance: none;
+}
+
+/* Table font and dropdown styling */
+#movies-calculator th,
+#movies-calculator td,
+#movies-manager th,
+#movies-manager td,
+#movies-calculator select,
+#movies-calculator input,
+#movies-manager select,
+#movies-manager input {
+    font-family: 'DTL', sans-serif;
+}
+
+.movie-select {
+    padding-left: 0.5rem;
+}
+
+.hour-select,
+.minute-select {
+    text-align: center;
+}
+
+.busy-checkbox:checked + div {
+    background-color: var(--primary-color);
 }
 
 /* Buttons */
@@ -117,17 +142,19 @@ input[type="text"], select {
 }
 
 .secondary-button {
-    background-color: var(--secondary-color);
-    color: white;
+    background-color: white;
+    color: var(--secondary-color);
+    border: 2px solid var(--secondary-color);
     font-weight: 700;
     font-family: 'DTL', sans-serif;
     padding: 0.75rem 1.5rem;
     border-radius: 0.5rem;
     box-shadow: 0 4px 6px rgba(0,0,0,0.1);
-    transition: transform 0.3s ease-in-out, background-color 0.3s ease-in-out, box-shadow 0.3s ease-in-out;
+    transition: transform 0.3s ease-in-out, background-color 0.3s ease-in-out, color 0.3s ease-in-out, box-shadow 0.3s ease-in-out;
 }
 .secondary-button:hover {
-    background-color: var(--primary-hover);
+    background-color: var(--secondary-color);
+    color: white;
     transform: scale(1.05);
     box-shadow: 0 4px 8px rgba(0,0,0,0.2);
 }

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <link rel="icon" type="image/png" href="images/favicon.png">
 </head>
 <body class="min-h-screen flex flex-col items-center justify-start p-4 sm:p-6 md:p-8">
-    <img src="images/logo_kokcinemaxx.png" alt="Logo" class="mx-auto mb-4 w-48">
+    <img src="images/logo_kokcinemaxx.png" alt="Logo" class="mb-4 w-48 self-start">
     <div class="main-container">
         <h1 class="page-title text-3xl sm:text-4xl font-bold text-center text-black mb-6">Pauze Planner</h1>
 
@@ -27,8 +27,8 @@
                 <label for="location-select" class="block text-sm font-bold mb-2 text-black">Kies Locatie:</label>
                 <select id="location-select" class="shadow appearance-none border rounded-md w-full py-2 px-3 text-black leading-tight focus:outline-none focus:shadow-outline">
                     <option value="none">-- Selecteer Locatie --</option>
-                    <option value="harderwijk">Harderwijk (5 Zalen)</option>
-                    <option value="lelystad">Lelystad (6 Zalen)</option>
+                    <option value="harderwijk">Harderwijk (5 zalen)</option>
+                    <option value="lelystad">Lelystad (6 zalen)</option>
                 </select>
             </div>
 
@@ -54,7 +54,7 @@
                 </button>
             </div>
 
-            <h2 class="text-xl font-semibold text-black mb-3">Resultaat:</h2>
+            <h2 id="result-header" class="text-xl font-semibold text-black mb-3 hidden">Resultaat:</h2>
             <!-- Output container for results, either single or multiple tabs -->
             <div id="output-wrapper" class="min-h-[80px] space-y-3">
                  <div id="output-tabs" class="hidden">

--- a/js/script.js
+++ b/js/script.js
@@ -19,6 +19,7 @@ const outputTabsContainer = document.getElementById('output-tabs'); // Container
 const outputTabButtonsDiv = outputTabsContainer.querySelector('.flex'); // Div for tab buttons
 const outputTabContentContainer = document.getElementById('output-tab-content-container'); // Container for tab content
 const singleOutputContainer = document.getElementById('single-output-container'); // Container for single result
+const resultHeader = document.getElementById('result-header');
 
 const importFileInput = document.getElementById('import-file-input');
 const importFilmsButton = document.getElementById('import-films-button');
@@ -255,7 +256,7 @@ ${minutes.map(m => `<option value="${m}">${m}</option>`).join('')}
 <td class="text-center">
 <label class="relative inline-flex items-center cursor-pointer">
 <input type="checkbox" class="busy-checkbox sr-only peer">
-<div class="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-blue-300 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-600"></div>
+<div class="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-blue-300 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-red-600"></div>
 <span class="ml-2 text-sm font-medium text-gray-700">Drukte</span>
 </label>
 </td>
@@ -265,9 +266,10 @@ calculatorTbody.appendChild(tr);
 populateMovieDropdowns(); // Populate dropdowns for new rows
 outputTabButtonsDiv.innerHTML = "";
 outputTabContentContainer.innerHTML = "";
-singleOutputContainer.innerHTML = "";
-outputTabsContainer.classList.add("hidden");
-singleOutputContainer.classList.add("hidden");
+    singleOutputContainer.innerHTML = "";
+    outputTabsContainer.classList.add("hidden");
+    singleOutputContainer.classList.add("hidden");
+    resultHeader.classList.add('hidden');
 }
 
 /**
@@ -395,10 +397,11 @@ return htmlParts.join('');
 * @param {boolean} isPerfectSolutionFound - True if at least one perfect solution was found.
 */
 function displayResults(solutions, isPerfectSolutionFound) {
-// Clear previous output
-outputTabButtonsDiv.innerHTML = '';
-outputTabContentContainer.innerHTML = '';
-singleOutputContainer.innerHTML = '';
+    // Clear previous output
+    outputTabButtonsDiv.innerHTML = '';
+    outputTabContentContainer.innerHTML = '';
+    singleOutputContainer.innerHTML = '';
+    resultHeader.classList.remove('hidden');
 
 if (isPerfectSolutionFound && solutions.length > 0) {
 // Display single best perfect solution
@@ -452,9 +455,10 @@ contentPane.classList.add('hidden');
 });
 } else {
 // No solutions found at all
-outputTabsContainer.classList.add('hidden');
-singleOutputContainer.classList.remove('hidden');
-singleOutputContainer.innerHTML = '<p class="text-gray-600">Geen combinatie gevonden die voldoet aan alle regels (inclusief "Drukte"-beperkingen).</p>';
+    outputTabsContainer.classList.add('hidden');
+    singleOutputContainer.classList.remove('hidden');
+    singleOutputContainer.innerHTML = '<p class="text-gray-600">Geen combinatie gevonden die voldoet aan alle regels (inclusief "Drukte"-beperkingen).</p>';
+    resultHeader.classList.remove('hidden');
 }
 }
 
@@ -475,10 +479,11 @@ singleOutputContainer.classList.add("hidden");
 
 
 if (movies.length === 0) {
-singleOutputContainer.innerHTML = '<p class="text-gray-600">Voer geldige filmdata in.</p>';
-outputTabsContainer.classList.add('hidden');
-singleOutputContainer.classList.remove('hidden');
-return;
+    singleOutputContainer.innerHTML = '<p class="text-gray-600">Voer geldige filmdata in.</p>';
+    outputTabsContainer.classList.add('hidden');
+    singleOutputContainer.classList.remove('hidden');
+    resultHeader.classList.remove('hidden');
+    return;
 }
 
 // Prepare option sets for each movie, converting start times and offsets to absolute minutes
@@ -493,10 +498,11 @@ isBusy: m.isBusy // Propagate the isBusy flag to each option
 }).filter(set => set.length > 0); // Filter out movies without valid options
 
 if (optionSets.length === 0) {
-singleOutputContainer.innerHTML = '<p class="text-gray-600">Geen geldige pauze-opties gevonden voor de geselecteerde films.</p>';
-outputTabsContainer.classList.add('hidden');
-singleOutputContainer.classList.remove('hidden');
-return;
+    singleOutputContainer.innerHTML = '<p class="text-gray-600">Geen geldige pauze-opties gevonden voor de geselecteerde films.</p>';
+    outputTabsContainer.classList.add('hidden');
+    singleOutputContainer.classList.remove('hidden');
+    resultHeader.classList.remove('hidden');
+    return;
 }
 
 const allCandidateSolutions = []; // Stores all valid (by busy rule) combinations
@@ -607,9 +613,10 @@ displayResults([bestPerfectSolution], true); // Found a perfect solution
 displayResults(fallbackSolutions, false); // No perfect solution, display top 3 best efforts
 } else {
 // No valid combinations found at all (even after busy check)
-singleOutputContainer.innerHTML = '<p class="text-gray-600">Geen combinatie gevonden die voldoet aan alle regels (inclusief "Drukte"-beperkingen).</p>';
-outputTabsContainer.classList.add('hidden');
-singleOutputContainer.classList.remove('hidden');
+    singleOutputContainer.innerHTML = '<p class="text-gray-600">Geen combinatie gevonden die voldoet aan alle regels (inclusief "Drukte"-beperkingen).</p>';
+    outputTabsContainer.classList.add('hidden');
+    singleOutputContainer.classList.remove('hidden');
+    resultHeader.classList.remove('hidden');
 }
 }
 


### PR DESCRIPTION
## Summary
- lighten tool background and center-left logo
- use DTL font inside tables and style dropdowns
- update button styling and toggle colour
- show results header only when displaying output
- small text and wording tweaks

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841af0b74088328940d20384521432c