### PR TITLE
Add settings tab and detailed explanation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Dit kleine webhulpmiddel berekent het beste pauzeschema voor filmvoorstellingen.
 3. Selecteer films en starttijden, markeer drukke films en klik op **Berekenen**.
 4. Beheer filmopties in het tabblad **Filmbeheer**. Je kunt films importeren of exporteren als JSON.
 
+5. Pas de minimale pauzekloof aan in het tabblad **Instellingen**.
 ## Ontwikkeling
 
 De app gebruikt Tailwind CDN en gewone JavaScript. Aangepaste stijlen staan in `styles.css` en het gedrag in `script.js`.

--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
         <div class="flex border-b border-gray-200 mb-6 rounded-t-xl overflow-hidden">
             <button id="tab-calculator" class="tab-button active flex-1">Planner</button>
             <button id="tab-film-management" class="tab-button flex-1">Filmbeheer</button>
+            <button id="tab-settings" class="tab-button flex-1">Instellingen</button>
             <button id="tab-explanation" class="tab-button flex-1">Uitleg</button>
         </div>
 
@@ -50,8 +51,6 @@
             </div>
 
             <div class="mb-4">
-                <label for="min-gap-input" class="block text-sm font-bold mb-2 text-black">Minimale pauzekloof (minuten):</label>
-                <input type="number" id="min-gap-input" min="0" class="shadow appearance-none border rounded-md w-full py-2 px-3 text-black leading-tight focus:outline-none focus:shadow-outline">
             </div>
 
             <div class="flex flex-col sm:flex-row justify-center sm:justify-start gap-4 mb-6">
@@ -108,12 +107,22 @@
             </div>
              <p id="film-management-message" class="mt-4 text-sm text-black"></p>
         </div>
+        <!-- Settings Tab Content -->
+        <div id="content-settings" class="tab-content hidden">
+            <h2 class="text-2xl font-bold text-black mb-4">Instellingen</h2>
+            <div class="mb-4">
+                <label for="min-gap-input" class="block text-sm font-bold mb-2 text-black">Minimale pauzekloof (minuten):</label>
+                <input type="number" id="min-gap-input" min="0" class="shadow appearance-none border rounded-md w-full py-2 px-3 text-black leading-tight focus:outline-none focus:shadow-outline">
+            </div>
+            <p class="text-black text-sm">De ingestelde waarde wordt lokaal opgeslagen.</p>
+        </div>
 
         <!-- Explanation Tab Content -->
         <div id="content-explanation" class="tab-content hidden">
             <h2 class="text-2xl font-bold text-black mb-4">Uitleg</h2>
-            <p class="mb-2 text-black">Gebruik de planner om snel pauzemomenten te vinden die aansluiten op de filmstarttijden. In het tabblad Filmbeheer kun je films toevoegen of importeren.</p>
-            <p class="text-black">Deze tool is bedoeld als hulp voor medewerkers van de bioscoop. Wees niet bang om te experimenteren; alle wijzigingen worden direct bijgehouden in je browser.</p>
+            <p class="mb-2 text-black">Selecteer je locatie en kies bij elke zaal een film met starttijd. Klik vervolgens op <strong>Berekenen</strong> om pauzemomenten te krijgen.</p>
+            <p class="mb-2 text-black">Vink <em>Drukte</em> aan wanneer een voorstelling erg populair is; de planner houdt dan minimaal de ingestelde pauzekloof aan.</p>
+            <p class="text-black">Onder <strong>Filmbeheer</strong> pas je de filmopties aan. In het tabblad <strong>Instellingen</strong> stel je de minimale pauzekloof in.</p>
         </div>
     </div>
 

--- a/js/script.js
+++ b/js/script.js
@@ -6,6 +6,8 @@ let filmData = [];
 const tabCalculatorBtn = document.getElementById('tab-calculator');
 const tabFilmManagerBtn = document.getElementById('tab-film-management');
 const tabExplanationBtn = document.getElementById('tab-explanation');
+const tabSettingsBtn = document.getElementById("tab-settings");
+const contentSettings = document.getElementById("content-settings");
 const contentCalculator = document.getElementById('content-calculator');
 const contentFilmManager = document.getElementById('content-film-management');
 const contentExplanation = document.getElementById('content-explanation');
@@ -51,6 +53,7 @@ if (minGapInput) {
 tabCalculatorBtn.addEventListener('click', () => showTab('calculator'));
 tabFilmManagerBtn.addEventListener('click', () => showTab('film-management'));
 tabExplanationBtn.addEventListener('click', () => showTab('explanation'));
+tabSettingsBtn.addEventListener("click", () => showTab("settings"));
 locationSelect.addEventListener('change', updateCalculatorRows);
 calculateBtn.addEventListener('click', calculate);
 addFilmManagerBtn.addEventListener('click', () => addFilmManagementRow());
@@ -83,24 +86,28 @@ updateCalculatorRows();
 * @param {string} tabName - The name of the tab to show ('calculator' or 'film-management').
 */
 function showTab(tabName) {
-// Update active state for tab buttons
-tabCalculatorBtn.classList.toggle('active', tabName === 'calculator');
-tabFilmManagerBtn.classList.toggle('active', tabName === 'film-management');
-tabExplanationBtn.classList.toggle('active', tabName === 'explanation');
+    // Update active state for tab buttons
+    tabCalculatorBtn.classList.toggle("active", tabName === "calculator");
+    tabFilmManagerBtn.classList.toggle("active", tabName === "film-management");
+    tabExplanationBtn.classList.toggle("active", tabName === "explanation");
+    tabSettingsBtn.classList.toggle("active", tabName === "settings");
 
-// Show/hide content divs
-contentCalculator.classList.toggle('hidden', tabName !== 'calculator');
-contentFilmManager.classList.toggle('hidden', tabName !== 'film-management');
-contentExplanation.classList.toggle('hidden', tabName !== 'explanation');
+    // Show/hide content sections
+    contentCalculator.classList.toggle("hidden", tabName !== "calculator");
+    contentFilmManager.classList.toggle("hidden", tabName !== "film-management");
+    contentSettings.classList.toggle("hidden", tabName !== "settings");
+    contentExplanation.classList.toggle("hidden", tabName !== "explanation");
 
-// If switching to film management, refresh its table
-if (tabName === 'film-management') {
-populateFilmManagementTable();
-filmManagementMessage.textContent = ''; // Clear message when opening tab
-} else if (tabName === 'calculator') {
-// If switching back to calculator, refresh dropdowns and rows
-updateCalculatorRows();
-}
+    if (tabName === "film-management") {
+        populateFilmManagementTable();
+        filmManagementMessage.textContent = "";
+    } else if (tabName === "calculator") {
+        updateCalculatorRows();
+    } else if (tabName === "settings") {
+        if (minGapInput) {
+            minGapInput.value = minGapRequired;
+        }
+    }
 }
 
 // --- Film Management Functions ---


### PR DESCRIPTION
## Summary
- add new **Instellingen** tab to adjust minimum pause gap
- move min gap input field to the settings tab
- improve explanation text and mention settings in README
- support new tab in JavaScript tab-switching logic

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6841b30337748328abaff3336b886980