### PR TITLE
Improve mobile layout

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -241,3 +241,30 @@ tbody tr:hover {
     background-color: var(--highlight-color);
 }
 
+/* Responsive table styling */
+@media (max-width: 640px) {
+    table.responsive-table thead {
+        display: none;
+    }
+
+    table.responsive-table tr {
+        display: block;
+        margin-bottom: 1rem;
+        border-bottom: 1px solid #D1D5DB;
+    }
+
+    table.responsive-table td {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        width: 100%;
+        padding: 0.5rem;
+    }
+
+    table.responsive-table td::before {
+        content: attr(data-label);
+        font-weight: 600;
+        margin-right: 0.5rem;
+    }
+}
+

--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
             </div>
 
             <div class="overflow-x-auto mb-6">
-                <table id="movies-calculator" class="min-w-full bg-background rounded-lg shadow-md overflow-hidden">
+                <table id="movies-calculator" class="responsive-table min-w-full bg-background rounded-lg shadow-md overflow-hidden">
                     <thead class="bg-highlight">
                         <tr>
                             <th class="text-left text-sm font-semibold text-black uppercase tracking-wider">Film</th>
@@ -80,7 +80,7 @@
         <div id="content-film-management" class="tab-content hidden">
             <h2 class="text-2xl font-bold text-black mb-4">Filmbeheer</h2>
             <div class="overflow-x-auto mb-6">
-                <table id="movies-manager" class="min-w-full bg-background rounded-lg shadow-md overflow-hidden">
+                <table id="movies-manager" class="responsive-table min-w-full bg-background rounded-lg shadow-md overflow-hidden">
                     <thead class="bg-highlight">
                         <tr>
                             <th class="text-left text-sm font-semibold text-black uppercase tracking-wider">Film Naam</th>

--- a/js/script.js
+++ b/js/script.js
@@ -120,9 +120,9 @@ function showTab(tabName) {
 function addFilmManagementRow(name = '', options = '') {
 const tr = document.createElement('tr');
 tr.innerHTML = `
-<td><input type="text" class="film-name-input" value="${name}" placeholder="Filmnaam" onchange="saveFilmData()"></td>
-<td><input type="text" class="film-options-input" placeholder="b.v. 45,60" value="${options}" onchange="saveFilmData()"></td>
-<td>
+<td data-label="Film Naam"><input type="text" class="film-name-input" value="${name}" placeholder="Filmnaam" onchange="saveFilmData()"></td>
+<td data-label="Pauze Opties (min)"><input type="text" class="film-options-input" placeholder="b.v. 45,60" value="${options}" onchange="saveFilmData()"></td>
+<td data-label="">
 <button onclick="removeFilmManagementRow(this)" class="remove-button" aria-label="Verwijderen">
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-5 h-5">
   <path fill-rule="evenodd" d="M16.5 4.478v.227a48.816 48.816 0 0 1 3.878.512.75.75 0 1 1-.256 1.478l-.209-.035-1.005 13.07a3 3 0 0 1-2.991 2.77H8.084a3 3 0 0 1-2.991-2.77L4.087 6.66l-.209.035a.75.75 0 0 1-.256-1.478A48.567 48.567 0 0 1 7.5 4.705v-.227c0-1.564 1.213-2.9 2.816-2.951a52.662 52.662 0 0 1 3.369 0c1.603.051 2.815 1.387 2.815 2.951Zm-6.136-1.452a51.196 51.196 0 0 1 3.273 0C14.39 3.05 15 3.684 15 4.478v.113a49.488 49.488 0 0 0-6 0v-.113c0-.794.609-1.428 1.364-1.452Zm-.355 5.945a.75.75 0 1 0-1.5.058l.347 9a.75.75 0 1 0 1.499-.058l-.346-9Zm5.48.058a.75.75 0 1 0-1.498-.058l-.347 9a.75.75 0 0 0 1.5.058l.345-9Z" clip-rule="evenodd"/>
@@ -268,13 +268,13 @@ const minutes = ['00', '15', '30', '45'];
 for (let i = 0; i < rowCount; i++) {
 const tr = document.createElement('tr');
 tr.innerHTML = `
-<td>
+<td data-label="Film">
 <select class="movie-select" onchange="onMovieSelectChange(this)">
 <option value="">-- Kies film --</option>
 <!-- Options will be populated by populateMovieDropdowns() -->
 </select>
 </td>
-<td>
+<td data-label="Starttijd">
 <div class="flex gap-1">
 <select class="hour-select w-1/2 p-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500">
 ${hours.map(h => `<option value="${h}">${h}</option>`).join('')}
@@ -285,8 +285,8 @@ ${minutes.map(m => `<option value="${m}">${m}</option>`).join('')}
 </select>
 </div>
 </td>
-<td class="hidden sm:table-cell"><input type="text" class="options" placeholder="b.v. 45,60" readonly></td>
-<td class="text-center">
+<td data-label="Pauzes"><input type="text" class="options" placeholder="b.v. 45,60" readonly></td>
+<td data-label="Drukte" class="text-center">
 <label class="relative inline-flex items-center cursor-pointer">
 <input type="checkbox" class="busy-checkbox sr-only peer">
 <div class="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-blue-300 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-red-600"></div>


### PR DESCRIPTION
## Summary
- mark tables with `responsive-table`
- add responsive styles for small screens
- add data labels in generated table cells

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6841bb0ea944832892a202b2020016ed