### PR TITLE
Update Drukte toggle layout and hide pauzes on mobile

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -285,12 +285,11 @@ ${minutes.map(m => `<option value="${m}">${m}</option>`).join('')}
 </select>
 </div>
 </td>
-<td data-label="Pauzes"><input type="text" class="options" placeholder="b.v. 45,60" readonly></td>
+<td data-label="Pauzes" class="hidden sm:table-cell"><input type="text" class="options" placeholder="b.v. 45,60" readonly></td>
 <td data-label="Drukte" class="text-center">
 <label class="relative inline-flex items-center cursor-pointer">
 <input type="checkbox" class="busy-checkbox sr-only peer">
 <div class="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-blue-300 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-red-600"></div>
-<span class="ml-2 text-sm font-medium text-gray-700">Drukte</span>
 </label>
 </td>
 `;


### PR DESCRIPTION
## Summary
- remove text label from the Drukte toggle
- hide the Pauzes column cells on mobile screens

## Testing
- `node --check js/script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6841bd55ea688328b41af5d88ec30fd6