### PR TITLE
Fix mobile hide for Pauzes column

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -294,6 +294,11 @@ tbody tr:hover {
         padding: 0.5rem;
     }
 
+    /* Ensure cells marked as hidden remain hidden on mobile */
+    table.responsive-table td.hidden {
+        display: none;
+    }
+
     table.responsive-table td::before {
         content: attr(data-label);
         font-weight: 600;


### PR DESCRIPTION
## Summary
- ensure table cells marked `hidden` stay hidden on mobile

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841c28586f0832883a746e04e8f0d72