### PR TITLE
Add location toggle in planner

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -307,3 +307,52 @@ tbody tr:hover {
     }
 }
 
+/* Location toggle styles */
+.location-toggle .toggle-label {
+    font-family: 'DTL', sans-serif;
+    font-weight: 600;
+}
+.location-toggle .toggle-label.highlight {
+    color: var(--primary-color);
+    font-weight: 700;
+}
+.switch {
+    position: relative;
+    display: inline-block;
+    width: 2.5rem;
+    height: 1.25rem;
+}
+.switch input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+.slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: #ccc;
+    transition: .4s;
+    border-radius: 9999px;
+}
+.slider:before {
+    position: absolute;
+    content: "";
+    height: 1rem;
+    width: 1rem;
+    left: 0.125rem;
+    bottom: 0.125rem;
+    background-color: white;
+    transition: .4s;
+    border-radius: 50%;
+}
+.switch input:checked + .slider {
+    background-color: var(--primary-color);
+}
+.switch input:checked + .slider:before {
+    transform: translateX(1.25rem);
+}
+

--- a/index.html
+++ b/index.html
@@ -28,11 +28,18 @@
         <!-- Calculator Tab Content -->
         <div id="content-calculator" class="tab-content">
             <div class="mb-4">
-                <label for="location-select" class="block text-sm font-bold mb-2 text-black">Kies Locatie:</label>
-                <select id="location-select" class="shadow appearance-none border rounded-md w-full py-2 px-3 text-black leading-tight focus:outline-none focus:shadow-outline">
-                    <option value="none">-- Selecteer Locatie --</option>
-                    <option value="harderwijk">Harderwijk (5 zalen)</option>
-                    <option value="lelystad">Lelystad (6 zalen)</option>
+                <label class="block text-sm font-bold mb-2 text-black">Kies Locatie:</label>
+                <div id="location-toggle" class="location-toggle flex items-center gap-2">
+                    <span id="label-harderwijk" class="toggle-label">Harderwijk</span>
+                    <label class="switch">
+                        <input type="checkbox" id="location-toggle-input">
+                        <span class="slider"></span>
+                    </label>
+                    <span id="label-lelystad" class="toggle-label">Lelystad</span>
+                </div>
+                <select id="location-select" class="hidden">
+                    <option value="harderwijk">Harderwijk</option>
+                    <option value="lelystad">Lelystad</option>
                 </select>
             </div>
 

--- a/js/script.js
+++ b/js/script.js
@@ -16,6 +16,9 @@ const calculatorTbody = document.querySelector('#movies-calculator tbody');
 const filmManagerTbody = document.querySelector('#movies-manager tbody');
 
 const locationSelect = document.getElementById('location-select');
+const locationToggleInput = document.getElementById('location-toggle-input');
+const labelHarderwijk = document.getElementById('label-harderwijk');
+const labelLelystad = document.getElementById('label-lelystad');
 const calculateBtn = document.getElementById('calculate');
 const addFilmManagerBtn = document.getElementById('add-film-manager');
 const outputWrapper = document.getElementById('output-wrapper'); // Main output wrapper
@@ -55,6 +58,22 @@ function applySlideIn(el) {
     }
 }
 
+function updateLabelHighlight() {
+    if (locationToggleInput.checked) {
+        labelHarderwijk.classList.add('highlight');
+        labelLelystad.classList.remove('highlight');
+    } else {
+        labelHarderwijk.classList.remove('highlight');
+        labelLelystad.classList.add('highlight');
+    }
+}
+
+function updateLocationFromToggle() {
+    locationSelect.value = locationToggleInput.checked ? 'lelystad' : 'harderwijk';
+    updateLabelHighlight();
+    updateCalculatorRows();
+}
+
 // Load saved value from localStorage
 const savedGap = localStorage.getItem('minGapRequired');
 if (savedGap !== null) {
@@ -87,6 +106,8 @@ if (defaultLocationSelect) {
         defaultLocation = defaultLocationSelect.value;
         localStorage.setItem('defaultLocation', defaultLocation);
         locationSelect.value = defaultLocation;
+        locationToggleInput.checked = defaultLocation === 'lelystad';
+        updateLabelHighlight();
         updateCalculatorRows();
     });
 }
@@ -105,6 +126,9 @@ tabFilmManagerBtn.addEventListener('click', () => showTab('film-management'));
 tabExplanationBtn.addEventListener('click', () => showTab('explanation'));
 tabSettingsBtn.addEventListener("click", () => showTab("settings"));
 locationSelect.addEventListener('change', updateCalculatorRows);
+if (locationToggleInput) {
+    locationToggleInput.addEventListener('change', updateLocationFromToggle);
+}
 calculateBtn.addEventListener('click', calculate);
 addFilmManagerBtn.addEventListener('click', () => addFilmManagementRow());
 importFilmsButton.addEventListener('click', () => importFileInput.click()); // Trigger hidden file input
@@ -131,6 +155,10 @@ showTab('calculator');
 populateFilmManagementTable();
 // Set initial location based on saved default
 locationSelect.value = defaultLocation;
+if (locationToggleInput) {
+    locationToggleInput.checked = defaultLocation === 'lelystad';
+    updateLabelHighlight();
+}
 updateCalculatorRows();
 if (appVersionElement) {
     appVersionElement.textContent = APP_VERSION;


### PR DESCRIPTION
## Summary
- switch location dropdown to a Harderwijk/Lelystad toggle
- highlight the opposite location when toggling

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841c2e196188328a2c7df2bff4acf2f