### PR TITLE
Add refresh button for default movies

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,6 +135,10 @@
                 <label for="max-results-input" class="block text-sm font-bold mb-2 text-black">Max aantal resultaatopties:</label>
                 <input type="number" id="max-results-input" min="1" class="shadow appearance-none border rounded-md w-full py-2 px-3 text-black leading-tight focus:outline-none focus:shadow-outline">
             </div>
+            <div class="mb-4">
+                <button id="refresh-films-button" class="primary-button w-full sm:w-auto">Herlaad standaard films</button>
+            </div>
+            <p id="settings-message" class="text-black text-sm mb-2"></p>
             <p class="text-black text-sm mb-2">Op deze pagina pas je alle voorkeuren voor de planner aan. De waarden worden lokaal opgeslagen zodat ze bij een volgend bezoek meteen actief zijn.</p>
             <p class="text-black text-sm mb-2"><strong>Minimale pauzekloof</strong> bepaalt hoeveel minuten er minimaal tussen twee drukke voorstellingen moeten zitten.</p>
             <p class="text-black text-sm mb-2"><strong>Standaardlocatie</strong> vult automatisch de juiste zalen in bij het openen van de planner.</p>

--- a/js/script.js
+++ b/js/script.js
@@ -36,6 +36,8 @@ const importFileInput = document.getElementById('import-file-input');
 const importFilmsButton = document.getElementById('import-films-button');
 const exportFilmsButton = document.getElementById('export-films-button');
 const filmManagementMessage = document.getElementById('film-management-message');
+const refreshFilmsButton = document.getElementById('refresh-films-button');
+const settingsMessage = document.getElementById('settings-message');
 
 // --- Helper ---
 function sortFilmData() {
@@ -182,6 +184,9 @@ calculateBtn.addEventListener('click', calculate);
 addFilmManagerBtn.addEventListener('click', () => addFilmManagementRow());
 importFilmsButton.addEventListener('click', () => importFileInput.click()); // Trigger hidden file input
 exportFilmsButton.addEventListener('click', exportFilms);
+if (refreshFilmsButton) {
+    refreshFilmsButton.addEventListener('click', refreshDefaultFilms);
+}
 
 
 // --- Initialization ---
@@ -271,6 +276,9 @@ function showTab(tabName) {
         }
         if (appVersionFooter) {
             appVersionFooter.textContent = APP_VERSION;
+        }
+        if (settingsMessage) {
+            settingsMessage.textContent = '';
         }
     }
 }
@@ -413,7 +421,35 @@ console.error('File reader error:', reader.error);
 };
 reader.readAsText(file);
 // Clear the input value to allow selecting the same file again if needed
-event.target.value = '';
+    event.target.value = '';
+}
+
+/**
+ * Reloads the default films from data/default_films.json and refreshes tables.
+ */
+function refreshDefaultFilms() {
+    if (settingsMessage) settingsMessage.textContent = '';
+    fetch('data/default_films.json')
+        .then(resp => resp.json())
+        .then(data => {
+            if (Array.isArray(data)) {
+                filmData = data;
+                sortFilmData();
+                populateFilmManagementTable();
+                populateMovieDropdowns();
+                if (settingsMessage) {
+                    settingsMessage.textContent = 'Standaardfilms opnieuw geladen.';
+                }
+            } else {
+                throw new Error('Ongeldig formaat van default_films.json');
+            }
+        })
+        .catch(err => {
+            if (settingsMessage) {
+                settingsMessage.textContent = `Fout bij laden: ${err.message}`;
+            }
+            console.error('Error refreshing films:', err);
+        });
 }
 
 // --- Calculator Tab Functions ---


### PR DESCRIPTION
## Summary
- add a 'Herlaad standaard films' button in settings
- implement `refreshDefaultFilms` to fetch data/default_films.json again
- show status message after reloading

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6849d22b61c083289c58d6ed5d5dbaca